### PR TITLE
fix: export non-Procedures TypeScript types

### DIFF
--- a/src/legacy/resolver.rs
+++ b/src/legacy/resolver.rs
@@ -122,5 +122,8 @@ pub fn typedef<TArg: Type, TResult: Type>(defs: &mut TypeMap) -> ProcedureDataTy
     let mut type_map = TypeMap::default();
     let arg_ty = TArg::reference(&mut type_map, &[]).inner;
     let result_ty = TResult::reference(&mut type_map, &[]).inner;
+
+    defs.append(&mut type_map);
+    
     ProcedureDataType { arg_ty, result_ty }
 }

--- a/src/legacy/resolver.rs
+++ b/src/legacy/resolver.rs
@@ -119,11 +119,8 @@ where
 }
 
 pub fn typedef<TArg: Type, TResult: Type>(defs: &mut TypeMap) -> ProcedureDataType {
-    let mut type_map = TypeMap::default();
-    let arg_ty = TArg::reference(&mut type_map, &[]).inner;
-    let result_ty = TResult::reference(&mut type_map, &[]).inner;
+    let arg_ty = TArg::reference(defs, &[]).inner;
+    let result_ty = TResult::reference(defs, &[]).inner;
 
-    defs.append(&mut type_map);
-    
     ProcedureDataType { arg_ty, result_ty }
 }

--- a/src/legacy/router.rs
+++ b/src/legacy/router.rs
@@ -11,7 +11,7 @@ use std::{
 use futures::Stream;
 use serde_json::Value;
 use specta::{datatype::FunctionResultVariant, DataType, TypeMap};
-use specta_typescript::{self as ts, datatype, Typescript};
+use specta_typescript::{self as ts, datatype, export_named_datatype, Typescript};
 
 use crate::{
     internal::{Procedure, ProcedureKind, ProcedureStore, RequestContext, ValueOrStream},
@@ -162,18 +162,12 @@ export type Procedures = {{
         )?;
 
         // Generate type exports (non-Procedures)
-        for (name, export) in self.type_map.iter().map(|(_, ty)| {
-            (
-                ty.name(),
-                datatype(
-                    &config,
-                    &FunctionResultVariant::Value(ty.inner.clone()),
-                    &self.type_map,
-                )
-                .unwrap(),
-            )
-        }) {
-            writeln!(file, "\nexport type {} = {};", name, export)?;
+        for export in self
+            .type_map
+            .iter()
+            .map(|(_, ty)| export_named_datatype(&config, ty, &self.type_map).unwrap())
+        {
+            writeln!(file, "\n{}", export)?;
         }
 
         Ok(())

--- a/src/legacy/router.rs
+++ b/src/legacy/router.rs
@@ -161,15 +161,19 @@ export type Procedures = {{
 }};"#
         )?;
 
-        for export in self.type_map.iter().map(|(_, ty)| {
-            datatype(
-                &config,
-                &FunctionResultVariant::Value(ty.inner.clone()),
-                &self.type_map,
+        // Generate type exports (non-Procedures)
+        for (name, export) in self.type_map.iter().map(|(_, ty)| {
+            (
+                ty.name(),
+                datatype(
+                    &config,
+                    &FunctionResultVariant::Value(ty.inner.clone()),
+                    &self.type_map,
+                )
+                .unwrap(),
             )
-            .unwrap()
         }) {
-            writeln!(file, "\n{}", export)?;
+            writeln!(file, "\nexport type {} = {};", name, export)?;
         }
 
         Ok(())


### PR DESCRIPTION
Should close #320.

Typemaps should now be correctly merged and exported. Let me know of any issues or things I've overlooked.