### PR TITLE
fix(packages): set an output directory

### DIFF
--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -1,5 +1,8 @@
 {
 	"extends": "../tsconfig.json",
+	"compilerOptions": {
+		"outDir": "dist"
+	},
 	"include": ["src/**/*"],
 	"exclude": ["dist/**/*"]
 }

--- a/packages/query-core/tsconfig.json
+++ b/packages/query-core/tsconfig.json
@@ -1,5 +1,8 @@
 {
 	"extends": "../tsconfig.json",
+	"compilerOptions": {
+		"outDir": "dist"
+	},
 	"include": ["src/**/*"],
 	"exclude": ["dist/**/*"]
 }

--- a/packages/react-query/tsconfig.json
+++ b/packages/react-query/tsconfig.json
@@ -2,6 +2,7 @@
 	"extends": "../tsconfig.json",
 	"compilerOptions": {
 		"jsx": "react-jsx",
+		"outDir": "dist"
 	},
 	"include": ["src/**/*"],
 	"exclude": ["dist/**/*"]


### PR DESCRIPTION
In my previous PR (#322), I mistakenly removed the TypeScript compiler options. As a result, `tsup` could no longer determine where to output the generated type definitions.

This PR restores the compiler options and specifies the correct output path.