### PR TITLE
Update rspc website link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
    A blazing fast and easy to use TRPC-like server for Rust.
  </strong>
 </div>
-<a align="center" href="https://rspc.otbeaumont.me">
+<a align="center" href="https://www.rspc.dev/">
   <p>Website</p>
 </a>
 


### PR DESCRIPTION
Just noticed that the website linked in the readme is no longer valid, updated it to https://www.rspc.dev/. Sorry for the tiny PR :sweat_smile: 