### PR TITLE
Fix router merging not working

### DIFF
--- a/rspc/src/router.rs
+++ b/rspc/src/router.rs
@@ -98,8 +98,6 @@ impl<TCtx> Router<TCtx> {
 
     #[track_caller]
     pub fn merge(mut self, mut other: Self) -> Self {
-        let error_count = self.errors.len();
-
         for (k, original) in other.procedures.iter() {
             if let Some(new) = self.procedures.get(k) {
                 self.errors.push(DuplicateProcedureKeyError {

--- a/rspc/src/router.rs
+++ b/rspc/src/router.rs
@@ -110,11 +110,9 @@ impl<TCtx> Router<TCtx> {
             }
         }
 
-        if self.errors.len() > error_count {
-            self.setup.append(&mut other.setup);
-            self.procedures.extend(other.procedures.into_iter());
-            self.errors.extend(other.errors);
-        }
+        self.setup.append(&mut other.setup);
+        self.procedures.extend(other.procedures.into_iter());
+        self.errors.extend(other.errors);
 
         self
     }

--- a/rspc/src/router.rs
+++ b/rspc/src/router.rs
@@ -85,6 +85,7 @@ impl<TCtx> Router<TCtx> {
                 path.extend(e.path);
                 DuplicateProcedureKeyError { path, ..e }
             }));
+            self.types.extend(other.types);
             self.procedures
                 .extend(other.procedures.into_iter().map(|(k, v)| {
                     let mut key = vec![prefix.clone()];
@@ -110,6 +111,7 @@ impl<TCtx> Router<TCtx> {
 
         self.setup.append(&mut other.setup);
         self.procedures.extend(other.procedures.into_iter());
+        self.types.extend(other.types);
         self.errors.extend(other.errors);
 
         self


### PR DESCRIPTION
Hi, it's awesome to see the procedure syntax coming together! I was having an issue when trying to merge a `legacy_router` with a new procedure router (`rspc@0.4.0` `rspc_axum@0.3.0` `rspc_legacy@0.0.1`).  The bindings output file would not show all of my procedures.

```rust
let rspc_router = rspc::Router::from(legacy_router().build()).merge(api::new());
let (procedures, types) = rspc_router.build().unwrap();
```

I looked at your code and found [the issue](https://github.com/specta-rs/rspc/blob/main/rspc/src/router.rs#L113-L117).I think it's okay to just ignore the errors at this point since they are checked when the user calls `build`. 
Let me know if I should change something, thanks.